### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube's Kubernetes Maven Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ The full code for the test app is available [here](https://github.com/IBM/spring
 with
 
 ```
-mvn package fabric8:build fabric8:resource fabric8:push fabric8:deploy
+mvn package k8s:build k8s:resource k8s:push k8s:deploy
 ```
 
 The maven pom file
-relies upon the [Fabric8 Maven Plugin](https://maven.fabric8.io/) to generate the
+relies upon the [Eclipse JKube](https://www.eclipse.org/jkube/)'s [Kubernetes Maven Plugin](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin) to generate the
 docker image for the app, push the docker image to the registry, generate the
 kubernetes deployment and service yaml, and apply them to the cluster.
 
@@ -252,12 +252,12 @@ call.
 If you require Istio behavior in these circumstances, you should be sure to invoke the Kubernetes Service
 URL, ( `http://servicename.servicenamespace.svc.cluster.local`) rather than a URL obtained via DiscoveryClient or via Ribbon.
 
-### Fabric8 Maven Plugin issues.
+### Eclipse JKube issues.
 
 Istio requires the ports for the container to be named as `grpc`,`redis`,`mongo`, `http` or `http2`.
 As per the Istio [Pod Spec Requeirements](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#pod-spec-requirements))
-Fabric8 Maven Plugin attempts to name the port based on the port number. For `8080`
-Fabric8 Maven Plugin knows it should assign the name `http`, but for port `9080`
+Eclipse JKube attempts to name the port based on the port number. For `8080`
+Eclipse JKube knows it should assign the name `http`, but for port `9080`
 (another common port used by well known Java app servers for http), it will assign the name `glrpc`.
 
 Having a port name other than one of the Istio recognized portnames, results in Istio not affecting
@@ -267,7 +267,7 @@ port names.
 >NOTE: If the port names do not match between the container and the service, an exception is thrown,
 and the connection is refused. This one caught me out for a while!
 
-I've yet to figure out how to convince Fabric8 Maven Plugin to allow me to define names for ports, so
+I've yet to figure out how to convince Eclipse JKube to allow me to define names for ports, so
 *if you plan to use this plugin with Istio, ensure you use port 80, 443, or 8080* to have the expected results.
 
 ### Istio initial startup networking

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -12,5 +12,5 @@ spec:
           - path: /
             backend:
               serviceName: k8sservice
-              servicePort: 9080 
+              servicePort: 8080
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<fabric8.generator.spring-boot.name>mycluster.icp:8500/default/demo:latest</fabric8.generator.spring-boot.name>
+                <jkube.version>1.0.0-rc-1</jkube.version>
 	</properties>
 
 	<dependencies>
@@ -64,62 +64,61 @@
 			<version>1.4.2.RELEASE</version>
 		</dependency>
 
-		<dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
+                <dependency>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
 
-		<!-- for  org.springframework.cloud.client.discovery  -->
-		<dependency>
-		    <groupId>org.springframework.cloud</groupId>
-		    <artifactId>spring-cloud-commons</artifactId>
-		    <version>1.3.1.RELEASE</version>
-		</dependency>
+                <!-- for  org.springframework.cloud.client.discovery  -->
+                <dependency>
+                  <groupId>org.springframework.cloud</groupId>
+                  <artifactId>spring-cloud-commons</artifactId>
+                  <version>1.3.1.RELEASE</version>
+                </dependency>
 
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>3.5.33</version>
-				<configuration>
-					<repository>mycluster.icp:8500/default/demo:latest</repository>
-            <images>
-              <image>
-               <name>mycluster.icp:8500/default/demo:latest</name>
-               <build>
-                <from>fabric8/java-jboss-openjdk8-jdk:1.2</from>
-                <cmd><shell>sleep 12; /deployments/run-java.sh</shell></cmd>
-                <assembly>
-                  <targetDir>/deployments</targetDir>
-                  <descriptorRef>artifact</descriptorRef>
-                </assembly>
-                <env><JAVA_APP_DIR>/deployments</JAVA_APP_DIR></env>
-                <ports><port>8080</port><port>8778</port><port>9779</port></ports>
-               </build>
-              </image>
-            </images>
-					<generator>
-						<includes>
-							<include>spring-boot</include>
-						</includes>
-					</generator>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+              <groupId>org.eclipse.jkube</groupId>
+              <artifactId>kubernetes-maven-plugin</artifactId>
+              <version>${jkube.version}</version>
+              <configuration>
+                <repository>mycluster.icp:8500/default/demo:latest</repository>
+                <images>
+                  <image>
+                    <name>mycluster.icp:8500/default/demo:latest</name>
+                    <build>
+                      <from>fabric8/java-jboss-openjdk8-jdk:1.2</from>
+                      <cmd><shell>sleep 12; /deployments/run-java.sh</shell></cmd>
+                      <assembly>
+                        <targetDir>/deployments</targetDir>
+                      </assembly>
+                      <env><JAVA_APP_DIR>/deployments</JAVA_APP_DIR></env>
+                      <ports><port>8080</port><port>8778</port><port>9779</port></ports>
+                    </build>
+                  </image>
+                </images>
+                <generator>
+                  <includes>
+                    <include>spring-boot</include>
+                  </includes>
+                </generator>
                 <enricher>
-                    <config>
-                        <fmp-controller>
-                            <pullPolicy>Always</pullPolicy>
-                        </fmp-controller>
-                    </config>
+                  <config>
+                    <jkube-controller>
+                      <pullPolicy>Always</pullPolicy>
+                    </jkube-controller>
+                  </config>
                 </enricher>
-				</configuration>
-      </plugin>
-		</plugins>
+	      </configuration>
+              </plugin>
+           </plugins>
 	</build>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-                <jkube.version>1.0.0-rc-1</jkube.version>
+                <jkube.version>1.0.1</jkube.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
[Eclipse JKube](https://github.com/eclipse/jkube) is new rebranded and refactored version of [Fabric8 Maven Plugin](https://github.com/fabric8io/fabric8-maven-plugin). In the future, support for Fabric8 Maven Plugin would be dropped.

Generated from Eclipse JKube [migrate goal](https://www.eclipse.org/jkube/docs/migration-guide/):
- For Red Hat OpenShift:
```
mvn org.eclipse.jkube:openshift-maven-plugin:migrate
```
- For Kubernetes:
```
mvn org.eclipse.jkube:kubernetes-maven-plugin:migrate
```